### PR TITLE
Fix error

### DIFF
--- a/Packages/MinimalUtility/Runtime/R3/DebugProfiler.cs
+++ b/Packages/MinimalUtility/Runtime/R3/DebugProfiler.cs
@@ -142,7 +142,6 @@ namespace MinimalUtility.R3
 
             await foreach (var unused in trigger.WithCancellation(cancellation))
             {
-                Debug.Log($"{Time.frameCount} gui");
                 GUI.Box(field, sb.ToString(), styleBox);
             }
         }

--- a/Packages/MinimalUtility/Runtime/R3/DebugProfiler.cs
+++ b/Packages/MinimalUtility/Runtime/R3/DebugProfiler.cs
@@ -125,6 +125,9 @@ namespace MinimalUtility.R3
             // 破壊されないように
             Object.DontDestroyOnLoad(instanceObj);
 
+            AsyncGUITrigger trigger = instanceObj.GetComponent<AsyncGUITrigger>();
+            await trigger.OnGUIAsync(cancellation);
+
             const int fontSize = 30;
             GUIStyle styleBox = new GUIStyle(GUI.skin.box)
             {
@@ -137,8 +140,9 @@ namespace MinimalUtility.R3
             };
             Rect field = new Rect(Screen.safeArea.position, debugArea);
 
-            await foreach (var unused in instanceObj.GetComponent<AsyncGUITrigger>().WithCancellation(cancellation))
+            await foreach (var unused in trigger.WithCancellation(cancellation))
             {
+                Debug.Log($"{Time.frameCount} gui");
                 GUI.Box(field, sb.ToString(), styleBox);
             }
         }


### PR DESCRIPTION
Dealing with this error as it occurs.
It is unclear why it did not occur before.

> ArgumentException: You can only call GUI functions from inside OnGUI.
UnityEngine.GUIUtility.CheckOnGUI () (at <74d6aaa3aedf4a279751914e170fef65>:0)
UnityEngine.GUI.get_skin () (at <74d6aaa3aedf4a279751914e170fef65>:0)